### PR TITLE
Remove nested navigation stacks

### DIFF
--- a/meditation/Views/Home/HomeTabView.swift
+++ b/meditation/Views/Home/HomeTabView.swift
@@ -11,13 +11,12 @@ struct HomeTabView: View {
     ]
 
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(spacing: 24) {
-                    Text("오늘의 기분은 어때요?")
-                        .font(.system(size: 22, weight: .bold))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal)
+        ScrollView {
+            VStack(spacing: 24) {
+                Text("오늘의 기분은 어때요?")
+                    .font(.system(size: 22, weight: .bold))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal)
 
                     LazyVGrid(columns: columns, spacing: 20) {
                         ForEach(moods) { mood in
@@ -50,9 +49,8 @@ struct HomeTabView: View {
                     }
                 }
                 .padding(.vertical)
-            }
-            .background(Color(selectedMood?.colorName ?? "SoftGray").opacity(0.15)) // ✅ 수정
-            .ignoresSafeArea(edges: .bottom)
         }
+        .background(Color(selectedMood?.colorName ?? "SoftGray").opacity(0.15)) // ✅ 수정
+        .ignoresSafeArea(edges: .bottom)
     }
 }

--- a/meditation/Views/Journal/HistoryTabView.swift
+++ b/meditation/Views/Journal/HistoryTabView.swift
@@ -4,9 +4,8 @@ struct HistoryTabView: View {
     @StateObject private var viewModel = JournalViewModel()
 
     var body: some View {
-        NavigationView {
-            ScrollView {
-                LazyVStack(spacing: 16) {
+        ScrollView {
+            LazyVStack(spacing: 16) {
                     ForEach(viewModel.entries) { entry in
                         VStack(alignment: .leading, spacing: 8) {
                             Text("🗓️ \(entry.date.formatted(.dateTime.year().month().day()))")
@@ -34,10 +33,9 @@ struct HistoryTabView: View {
                     }
                 }
                 .padding(.top)
-            }
-            .background(Color("SoftGray").ignoresSafeArea())
-            .navigationTitle("감정 일지")
         }
+        .background(Color("SoftGray").ignoresSafeArea())
+        .navigationTitle("감정 일지")
         .onAppear {
             viewModel.fetchJournals()
         }

--- a/meditation/Views/Profile/ProfileTabView.swift
+++ b/meditation/Views/Profile/ProfileTabView.swift
@@ -6,8 +6,7 @@ struct ProfileTabView: View {
     @State private var userEmail: String = Auth.auth().currentUser?.email ?? "Unknown"
     
     var body: some View {
-        NavigationView {
-            VStack(spacing: 32) {
+        VStack(spacing: 32) {
                 // 사용자 이메일 표시
                 VStack(spacing: 4) {
                     Text("Logged in as")
@@ -43,10 +42,9 @@ struct ProfileTabView: View {
                 }
 
                 Spacer()
-            }
-            .padding(.top, 60)
-            .navigationTitle("프로필")
         }
+        .padding(.top, 60)
+        .navigationTitle("프로필")
     }
 
     private func logout() {


### PR DESCRIPTION
## Summary
- rely on single NavigationStack in `AppRootView`
- drop `NavigationStack` wrapper from `HomeTabView`
- remove stray `NavigationView` wrappers from profile and history tabs

## Testing
- `xcodebuild test -project Meditation.xcodeproj -scheme Meditation -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68561317553c8331a0595c68090a0927