### PR TITLE
Implement meditation settings view

### DIFF
--- a/meditation/App/AppRootView.swift
+++ b/meditation/App/AppRootView.swift
@@ -36,6 +36,12 @@ struct AppRootView: View {
                 navigate: appState.navigate
             )
 
+        case .meditationSetup(let mood):
+            MeditationSetupView(
+                mood: mood,
+                navigate: appState.navigate
+            )
+
         case .meditation(let duration, let mood, let music):
             MeditationStartView(
                 durationMinutes: duration,

--- a/meditation/App/Route.swift
+++ b/meditation/App/Route.swift
@@ -4,6 +4,7 @@ enum Route: Hashable {
     case launch
     case home
     case content(Mood)
+    case meditationSetup(Mood)
     case meditation(duration: Int, mood: Mood, music: String)
     case journalEditor(entry: JournalEntry?)
     case stats

--- a/meditation/Views/Home/ContentView.swift
+++ b/meditation/Views/Home/ContentView.swift
@@ -24,8 +24,7 @@ struct ContentView: View {
             Spacer()
 
             Button(action: {
-                // 타이머 5분 + 음악 임시 선택
-                navigate(.meditation(duration: 5, mood: mood, music: "meditation1"))
+                navigate(.meditationSetup(mood))
             }) {
                 Text("명상 시작하기")
                     .frame(maxWidth: .infinity)

--- a/meditation/Views/Meditation/MeditationSetupView.swift
+++ b/meditation/Views/Meditation/MeditationSetupView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct MeditationSetupView: View {
+    let mood: Mood
+    let navigate: (Route) -> Void
+
+    @State private var duration: Int = 5
+    @State private var selectedMusic: String = "meditation1"
+
+    private let musicOptions = ["meditation1", "meditation2", "meditation3"]
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            VStack {
+                Text("명상 시간: \(duration)분")
+                    .font(.title2)
+                Stepper("시간 선택", value: $duration, in: 1...60)
+            }
+            .padding()
+
+            VStack(alignment: .leading, spacing: 12) {
+                Text("배경 음악")
+                    .font(.title3)
+                Picker("음악", selection: $selectedMusic) {
+                    ForEach(musicOptions, id: \.self) { option in
+                        Text(option)
+                            .tag(option)
+                    }
+                }
+                .pickerStyle(SegmentedPickerStyle())
+            }
+            .padding()
+
+            Spacer()
+
+            Button(action: {
+                navigate(.meditation(duration: duration, mood: mood, music: selectedMusic))
+            }) {
+                Text("명상 시작하기")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color(mood.colorName))
+                    .foregroundColor(.white)
+                    .cornerRadius(16)
+            }
+            .padding(.horizontal)
+        }
+        .padding()
+        .navigationTitle("명상 설정")
+    }
+}


### PR DESCRIPTION
## Summary
- add new route case `meditationSetup`
- introduce `MeditationSetupView` to pick duration and music before starting
- update `AppRootView` navigation
- connect new setup flow from `ContentView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6856257cae088331bc24d68b4da6b977