### PR TITLE
Add journal creation button

### DIFF
--- a/meditation/Views/Journal/HistoryTabView.swift
+++ b/meditation/Views/Journal/HistoryTabView.swift
@@ -47,8 +47,26 @@ struct HistoryTabView: View {
         }
         .background(Color("SoftGray").ignoresSafeArea())
         .navigationTitle("감정 일지")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: addEntry) {
+                    Image(systemName: "plus")
+                }
+            }
+        }
         .onAppear {
             viewModel.fetchJournals()
         }
+    }
+
+    private func addEntry() {
+        let mood = Mood.sampleMoods.first?.name ?? ""
+        let newEntry = JournalEntry(
+            mood: mood,
+            text: "",
+            durationMinutes: 0,
+            date: Date()
+        )
+        appState.navigate(to: .journalEditor(entry: newEntry))
     }
 }


### PR DESCRIPTION
## Summary
- add toolbar button in `HistoryTabView` to create a new journal entry
- new journal item starts with the first sample mood and the current time

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685636739c048331a182c5ded8155c60