### PR TITLE
Manage Firestore listener for journal history

### DIFF
--- a/meditation/ViewModels/JournalViewModel.swift
+++ b/meditation/ViewModels/JournalViewModel.swift
@@ -4,8 +4,9 @@ import FirebaseAuth
 
 class JournalViewModel: ObservableObject {
     @Published var entries: [JournalEntry] = []
-    
+
     private let db = Firestore.firestore()
+    private var listener: ListenerRegistration?
     
     // MARK: - 감정 일기 저장
     func saveJournal(mood: String, text: String, durationMinutes: Int, completion: @escaping (Result<Void, Error>) -> Void) {
@@ -93,7 +94,7 @@ class JournalViewModel: ObservableObject {
     func fetchJournals() {
         guard let userId = Auth.auth().currentUser?.uid else { return }
 
-        db.collection("users").document(userId)
+        listener = db.collection("users").document(userId)
             .collection("journals")
             .order(by: "date", descending: true)
             .addSnapshotListener { snapshot, error in
@@ -103,5 +104,10 @@ class JournalViewModel: ObservableObject {
                     }
                 }
             }
+    }
+
+    func removeListener() {
+        listener?.remove()
+        listener = nil
     }
 }

--- a/meditation/Views/Journal/HistoryTabView.swift
+++ b/meditation/Views/Journal/HistoryTabView.swift
@@ -50,5 +50,8 @@ struct HistoryTabView: View {
         .onAppear {
             viewModel.fetchJournals()
         }
+        .onDisappear {
+            viewModel.removeListener()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow `JournalViewModel` to store a Firestore `ListenerRegistration`
- expose `removeListener()` for detaching the history listener
- stop the snapshot listener when `HistoryTabView` disappears

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685636782050833187fc724cc40bdc0b