### PR TITLE
Enhance journal history with mood visuals

### DIFF
--- a/meditation/Models/Mood.swift
+++ b/meditation/Models/Mood.swift
@@ -14,4 +14,9 @@ struct Mood: Identifiable, Equatable, Hashable {
         Mood(id: "calm", name: "평온", emoji: "😌", colorName: "SoftGreen", message: "지금의 평온함을 고요하게 이어가보세요."),
         Mood(id: "anxious", name: "불안", emoji: "😰", colorName: "Lavender", message: "불안한 마음을 부드럽게 안아주세요.")
     ]
+
+    /// Helper to look up a `Mood` by its identifier string stored in `JournalEntry.mood`.
+    static func mood(for id: String) -> Mood? {
+        sampleMoods.first { $0.id == id }
+    }
 }

--- a/meditation/Views/Journal/HistoryTabView.swift
+++ b/meditation/Views/Journal/HistoryTabView.swift
@@ -8,20 +8,38 @@ struct HistoryTabView: View {
         ScrollView {
             LazyVStack(spacing: 16) {
                     ForEach(viewModel.entries) { entry in
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("🗓️ \(entry.date.formatted(.dateTime.year().month().day()))")
-                                .font(.caption)
-                                .foregroundColor(.gray)
+                        let mood = Mood.mood(for: entry.mood)
 
-                            Text("감정: \(entry.mood)")
-                                .font(.headline)
+                        HStack(alignment: .top, spacing: 12) {
+                            if let mood = mood {
+                                Text(mood.emoji)
+                                    .font(.title)
+                                    .frame(width: 44, height: 44)
+                                    .background(Color(mood.colorName))
+                                    .clipShape(Circle())
+                            }
 
-                            Text(entry.text)
-                                .lineLimit(3)
-                                .foregroundColor(.secondary)
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text("🗓️ \(entry.date.formatted(.dateTime.year().month().day()))")
+                                    .font(.caption)
+                                    .foregroundColor(.gray)
+
+                                if let mood = mood {
+                                    Text(mood.name)
+                                        .font(.headline)
+                                } else {
+                                    Text(entry.mood)
+                                        .font(.headline)
+                                }
+
+                                Text(entry.text)
+                                    .lineLimit(3)
+                                    .foregroundColor(.secondary)
+                            }
                         }
                         .padding()
-                        .background(Color.white)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color(mood?.colorName ?? "white").opacity(0.1))
                         .cornerRadius(16)
                         .shadow(color: .gray.opacity(0.1), radius: 2, x: 0, y: 2)
                         .padding(.horizontal)


### PR DESCRIPTION
## Summary
- add helper to look up `Mood` by id
- display mood emoji and color in journal history cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856367fb90083318897ad082902d2e8