### PR TITLE
Add fading placeholder to JournalEditorView

### DIFF
--- a/meditation/Views/Journal/JournalEditorView.swift
+++ b/meditation/Views/Journal/JournalEditorView.swift
@@ -28,11 +28,23 @@ struct JournalEditorView: View {
                 .font(.subheadline)
                 .foregroundColor(.gray)
 
-            TextEditor(text: $text)
-                .frame(height: 200)
-                .padding()
-                .background(Color(.systemGray6))
-                .cornerRadius(12)
+            ZStack(alignment: .topLeading) {
+                if text.isEmpty {
+                    Text("오늘의 감정을 적어보세요…")
+                        .foregroundColor(.gray)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 12)
+                        .opacity(text.isEmpty ? 1 : 0)
+                        .animation(.easeInOut, value: text)
+                        .allowsHitTesting(false)
+                }
+
+                TextEditor(text: $text)
+                    .frame(height: 200)
+                    .padding()
+                    .background(Color(.systemGray6))
+                    .cornerRadius(12)
+            }
 
             if isSaving {
                 ProgressView()


### PR DESCRIPTION
## Summary
- overlay a fading placeholder on the text editor when editing journal entries

## Testing
- `xcodebuild -list -project Meditation.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856368386bc8331aa39f719935c414b