### PR TITLE
Fill remaining stubs

### DIFF
--- a/meditation/Services/AudioPlayerService.swift
+++ b/meditation/Services/AudioPlayerService.swift
@@ -1,8 +1,30 @@
-//
-//  AudioPlayerService.swift
-//  Meditation
-//
-//  Created by 김태우 on 6/20/25.
-//
-
 import Foundation
+import AVFoundation
+
+class AudioPlayerService {
+    static let shared = AudioPlayerService()
+    private var player: AVAudioPlayer?
+
+    private init() {}
+
+    func play(name: String, fileExtension: String = "mp3", loops: Int = 0) {
+        stop()
+        guard let url = Bundle.main.url(forResource: name, withExtension: fileExtension) else {
+            print("오디오 파일을 찾을 수 없습니다: \(name)")
+            return
+        }
+        do {
+            player = try AVAudioPlayer(contentsOf: url)
+            player?.numberOfLoops = loops
+            player?.play()
+        } catch {
+            print("오디오 재생 오류: \(error)")
+        }
+    }
+
+    func stop() {
+        player?.stop()
+        player = nil
+    }
+}
+

--- a/meditation/Services/FirebaseManager.swift
+++ b/meditation/Services/FirebaseManager.swift
@@ -1,8 +1,15 @@
-//
-//  FirebaseManager.swift
-//  Meditation
-//
-//  Created by 김태우 on 6/20/25.
-//
-
 import Foundation
+import FirebaseCore
+
+class FirebaseManager {
+    static let shared = FirebaseManager()
+
+    private init() {}
+
+    func configure() {
+        if FirebaseApp.app() == nil {
+            FirebaseApp.configure()
+        }
+    }
+}
+

--- a/meditation/ViewModels/AppStateViewModel.swift
+++ b/meditation/ViewModels/AppStateViewModel.swift
@@ -1,8 +1,50 @@
-//
-//  AppStateViewModel.swift
-//  Meditation
-//
-//  Created by 김태우 on 6/20/25.
-//
-
 import Foundation
+import FirebaseAuth
+import SwiftUI
+
+class AppStateViewModel: ObservableObject {
+    @Published var path: [Route] = []
+    @Published var isLoggedIn: Bool = false
+
+    private var authListenerHandle: AuthStateDidChangeListenerHandle?
+
+    init() {
+        observeAuthChanges()
+    }
+
+    private func observeAuthChanges() {
+        authListenerHandle = Auth.auth().addStateDidChangeListener { [weak self] _, user in
+            DispatchQueue.main.async {
+                self?.isLoggedIn = (user != nil)
+                if user == nil {
+                    self?.path = []
+                }
+            }
+        }
+    }
+
+    func navigate(to route: Route) {
+        switch route {
+        case .launch:
+            path = []
+            isLoggedIn = false
+        case .home:
+            path = []
+            isLoggedIn = true
+        default:
+            path.append(route)
+        }
+    }
+
+    func reset() {
+        path = []
+        isLoggedIn = false
+    }
+
+    deinit {
+        if let handle = authListenerHandle {
+            Auth.auth().removeStateDidChangeListener(handle)
+        }
+    }
+}
+

--- a/meditation/Views/Auth/LoginView.swift
+++ b/meditation/Views/Auth/LoginView.swift
@@ -1,8 +1,61 @@
-//
-//  LoginView.swift
-//  Meditation
-//
-//  Created by 김태우 on 6/20/25.
-//
+import SwiftUI
 
-import Foundation
+struct LoginView: View {
+    @StateObject private var viewModel = AuthViewModel()
+    let navigate: (Route) -> Void
+
+    var body: some View {
+        VStack(spacing: 28) {
+            Spacer()
+
+            VStack(spacing: 12) {
+                Image(systemName: "leaf.circle.fill")
+                    .resizable()
+                    .frame(width: 80, height: 80)
+                    .foregroundColor(.green)
+
+                Text("숨결")
+                    .font(.largeTitle.bold())
+            }
+
+            VStack(spacing: 12) {
+                TextField("Email", text: $viewModel.email)
+                    .keyboardType(.emailAddress)
+                    .autocapitalization(.none)
+                    .padding()
+                    .background(Color(.secondarySystemBackground))
+                    .cornerRadius(12)
+
+                SecureField("Password", text: $viewModel.password)
+                    .padding()
+                    .background(Color(.secondarySystemBackground))
+                    .cornerRadius(12)
+            }
+            .padding(.horizontal)
+
+            if let error = viewModel.errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+
+            VStack(spacing: 12) {
+                RoundedButton(title: "로그인", backgroundColor: .green) {
+                    viewModel.signIn {
+                        navigate(.home)
+                    }
+                }
+
+                Button("회원가입") {
+                    navigate(.profile) // Placeholder: navigate to signup route
+                }
+                .foregroundColor(.gray)
+            }
+            .padding(.horizontal)
+
+            Spacer()
+        }
+        .padding()
+    }
+}
+

--- a/meditation/Views/Auth/SignupView.swift
+++ b/meditation/Views/Auth/SignupView.swift
@@ -1,8 +1,61 @@
-//
-//  SignupView.swift
-//  Meditation
-//
-//  Created by 김태우 on 6/20/25.
-//
+import SwiftUI
 
-import Foundation
+struct SignupView: View {
+    @StateObject private var viewModel = AuthViewModel()
+    let navigate: (Route) -> Void
+
+    var body: some View {
+        VStack(spacing: 28) {
+            Spacer()
+
+            VStack(spacing: 12) {
+                Image(systemName: "person.crop.circle.fill")
+                    .resizable()
+                    .frame(width: 80, height: 80)
+                    .foregroundColor(.accentColor)
+
+                Text("회원가입")
+                    .font(.largeTitle.bold())
+            }
+
+            VStack(spacing: 12) {
+                TextField("Email", text: $viewModel.email)
+                    .keyboardType(.emailAddress)
+                    .autocapitalization(.none)
+                    .padding()
+                    .background(Color(.secondarySystemBackground))
+                    .cornerRadius(12)
+
+                SecureField("Password", text: $viewModel.password)
+                    .padding()
+                    .background(Color(.secondarySystemBackground))
+                    .cornerRadius(12)
+            }
+            .padding(.horizontal)
+
+            if let error = viewModel.errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+
+            VStack(spacing: 12) {
+                RoundedButton(title: "회원가입", backgroundColor: .accentColor) {
+                    viewModel.signUp {
+                        navigate(.home)
+                    }
+                }
+
+                Button("이미 계정이 있으신가요?") {
+                    navigate(.launch)
+                }
+                .foregroundColor(.gray)
+            }
+            .padding(.horizontal)
+
+            Spacer()
+        }
+        .padding()
+    }
+}
+

--- a/meditation/Views/Components/MeditationProgressView.swift
+++ b/meditation/Views/Components/MeditationProgressView.swift
@@ -1,8 +1,21 @@
-//
-//  MeditationProgressView.swift
-//  Meditation
-//
-//  Created by 김태우 on 6/20/25.
-//
+import SwiftUI
 
-import Foundation
+struct MeditationProgressView: View {
+    let progress: Double
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.gray.opacity(0.3), lineWidth: 12)
+            Circle()
+                .trim(from: 0, to: progress)
+                .stroke(
+                    Color.accentColor,
+                    style: StrokeStyle(lineWidth: 12, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+        }
+        .frame(width: 140, height: 140)
+        .animation(.easeInOut, value: progress)
+    }
+}
+

--- a/meditation/Views/Components/RoundedButton.swift
+++ b/meditation/Views/Components/RoundedButton.swift
@@ -1,8 +1,21 @@
-//
-//  RoundedButton.swift
-//  Meditation
-//
-//  Created by 김태우 on 6/20/25.
-//
+import SwiftUI
 
-import Foundation
+struct RoundedButton: View {
+    var title: String
+    var backgroundColor: Color = .accentColor
+    var textColor: Color = .white
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 18, weight: .bold))
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(backgroundColor)
+                .foregroundColor(textColor)
+                .cornerRadius(16)
+        }
+    }
+}
+

--- a/meditation/Views/Home/MoodSelectionView.swift
+++ b/meditation/Views/Home/MoodSelectionView.swift
@@ -1,8 +1,45 @@
-//
-//  MoodSelectionView.swift
-//  Meditation
-//
-//  Created by 김태우 on 6/20/25.
-//
+import SwiftUI
 
-import Foundation
+struct MoodSelectionView: View {
+    @EnvironmentObject var appState: AppState
+    private let moods = Mood.sampleMoods
+    @State private var selectedMood: Mood?
+
+    private let columns: [GridItem] = [
+        GridItem(.flexible()),
+        GridItem(.flexible())
+    ]
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                Text("오늘의 기분은 어때요?")
+                    .font(.system(size: 22, weight: .bold))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal)
+
+                LazyVGrid(columns: columns, spacing: 20) {
+                    ForEach(moods) { mood in
+                        MoodCardView(mood: mood, isSelected: selectedMood == mood)
+                            .onTapGesture {
+                                selectedMood = mood
+                            }
+                    }
+                }
+                .padding(.horizontal)
+
+                if let mood = selectedMood {
+                    RoundedButton(title: "선택", backgroundColor: Color(mood.colorName)) {
+                        appState.navigate(to: .content(mood))
+                    }
+                    .padding(.horizontal)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .animation(.spring(), value: selectedMood)
+                }
+            }
+            .padding(.vertical)
+        }
+        .navigationTitle("감정 선택")
+    }
+}
+

--- a/meditation/Views/Launch/SplashView.swift
+++ b/meditation/Views/Launch/SplashView.swift
@@ -1,8 +1,26 @@
-//
-//  SplashView.swift
-//  Meditation
-//
-//  Created by 김태우 on 6/20/25.
-//
+import SwiftUI
 
-import Foundation
+struct SplashView: View {
+    let navigate: (Route) -> Void
+
+    var body: some View {
+        ZStack {
+            Color.white.ignoresSafeArea()
+
+            VStack(spacing: 12) {
+                Image(systemName: "leaf.circle.fill")
+                    .resizable()
+                    .frame(width: 100, height: 100)
+                    .foregroundColor(.green)
+                Text("숨결")
+                    .font(.largeTitle.bold())
+            }
+        }
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                navigate(.launch)
+            }
+        }
+    }
+}
+

--- a/meditation/Views/Meditation/MeditationSummaryView.swift
+++ b/meditation/Views/Meditation/MeditationSummaryView.swift
@@ -1,8 +1,60 @@
-//
-//  MeditationSummaryView.swift
-//  Meditation
-//
-//  Created by 김태우 on 6/20/25.
-//
+import SwiftUI
 
-import Foundation
+struct MeditationSummaryView: View {
+    let durationMinutes: Int
+    let mood: Mood
+    let onDone: () -> Void
+
+    @State private var note: String = ""
+    @State private var isSaving = false
+    @StateObject private var journalViewModel = JournalViewModel()
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("명상 완료")
+                .font(.title)
+
+            Text("\(durationMinutes)분 동안 \(mood.name) 명상을 했어요")
+                .foregroundColor(.secondary)
+
+            TextEditor(text: $note)
+                .frame(height: 120)
+                .padding()
+                .background(Color(.systemGray6))
+                .cornerRadius(12)
+                .overlay(
+                    Group {
+                        if note.isEmpty {
+                            Text("느낀 점을 기록해보세요...")
+                                .foregroundColor(.gray)
+                                .padding(.leading, 8)
+                                .padding(.top, 12)
+                                .allowsHitTesting(false)
+                        }
+                    }, alignment: .topLeading
+                )
+
+            if isSaving {
+                ProgressView()
+            } else {
+                RoundedButton(title: "저장", backgroundColor: Color(mood.colorName)) {
+                    save()
+                }
+            }
+
+            Spacer()
+        }
+        .padding()
+    }
+
+    private func save() {
+        isSaving = true
+        journalViewModel.saveJournal(mood: mood.name, text: note, durationMinutes: durationMinutes) { _ in
+            DispatchQueue.main.async {
+                isSaving = false
+                onDone()
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement missing services such as `AudioPlayerService` and `FirebaseManager`
- add `AppStateViewModel` for navigation state
- provide basic login/signup screens and splash view
- create reusable `RoundedButton` and `MeditationProgressView`
- add mood selection and meditation summary views

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68563f05c2b48331bc388b96aa4a11d2