### PR TITLE
Refactor audio playback with service

### DIFF
--- a/meditation/Services/AudioPlayerService.swift
+++ b/meditation/Services/AudioPlayerService.swift
@@ -6,3 +6,42 @@
 //
 
 import Foundation
+import AVFoundation
+
+class AudioPlayerService {
+    static let shared = AudioPlayerService()
+
+    private var audioPlayer: AVAudioPlayer?
+
+    private init() {}
+
+    /// Play a sound file from the app bundle.
+    /// - Parameters:
+    ///   - name: File name without extension.
+    ///   - loop: If true the sound will loop indefinitely.
+    func play(_ name: String, loop: Bool = false) {
+        stop()
+        guard let url = Bundle.main.url(forResource: name, withExtension: "mp3") else {
+            return
+        }
+
+        do {
+            audioPlayer = try AVAudioPlayer(contentsOf: url)
+            audioPlayer?.numberOfLoops = loop ? -1 : 0
+            audioPlayer?.play()
+        } catch {
+            print("오디오 재생 실패: \(error)")
+        }
+    }
+
+    /// Pause the currently playing sound.
+    func pause() {
+        audioPlayer?.pause()
+    }
+
+    /// Stop playing and release the audio player.
+    func stop() {
+        audioPlayer?.stop()
+        audioPlayer = nil
+    }
+}

--- a/meditation/ViewModels/MeditationViewModel.swift
+++ b/meditation/ViewModels/MeditationViewModel.swift
@@ -1,12 +1,10 @@
 import Foundation
-import AVFoundation
 
 class MeditationViewModel: ObservableObject {
     @Published var remainingSeconds: Int
     @Published var isMeditating: Bool = false
 
     private var timer: Timer?
-    private var audioPlayer: AVAudioPlayer?
 
     let durationMinutes: Int
     let music: String
@@ -30,19 +28,12 @@ class MeditationViewModel: ObservableObject {
             }
         }
 
-        if let url = Bundle.main.url(forResource: music, withExtension: "mp3") {
-            do {
-                audioPlayer = try AVAudioPlayer(contentsOf: url)
-                audioPlayer?.play()
-            } catch {
-                print("오디오 재생 오류: \(error)")
-            }
-        }
+        AudioPlayerService.shared.play(music)
     }
 
     func endMeditation() {
         timer?.invalidate()
-        audioPlayer?.stop()
+        AudioPlayerService.shared.stop()
         isMeditating = false
     }
 

--- a/meditation/Views/Meditation/MeditationSetupView.swift
+++ b/meditation/Views/Meditation/MeditationSetupView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import AVFoundation
 
 struct MeditationSetupView: View {
     let mood: Mood
@@ -7,7 +6,6 @@ struct MeditationSetupView: View {
 
     @State private var duration: Int = 5
     @State private var selectedMusic: String = "meditation1"
-    @State private var audioPlayer: AVAudioPlayer?
 
     private let musicOptions = ["meditation1", "meditation2", "meditation3"]
 
@@ -38,7 +36,7 @@ struct MeditationSetupView: View {
             Spacer()
 
             Button(action: {
-                audioPlayer?.stop()
+                AudioPlayerService.shared.stop()
                 navigate(.meditation(duration: duration, mood: mood, music: selectedMusic))
             }) {
                 Text("명상 시작하기")
@@ -52,24 +50,15 @@ struct MeditationSetupView: View {
         }
         .padding()
         .navigationTitle("명상 설정")
-        .onAppear(perform: playMusic)
+        .onAppear {
+            AudioPlayerService.shared.play(selectedMusic, loop: true)
+        }
         .onChange(of: selectedMusic) { _ in
-            playMusic()
+            AudioPlayerService.shared.play(selectedMusic, loop: true)
         }
         .onDisappear {
-            audioPlayer?.stop()
+            AudioPlayerService.shared.stop()
         }
     }
 
-    private func playMusic() {
-        audioPlayer?.stop()
-        guard let url = Bundle.main.url(forResource: selectedMusic, withExtension: "mp3") else { return }
-        do {
-            audioPlayer = try AVAudioPlayer(contentsOf: url)
-            audioPlayer?.numberOfLoops = -1
-            audioPlayer?.play()
-        } catch {
-            print("오디오 재생 실패: \(error.localizedDescription)")
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- implement `AudioPlayerService` with play, pause and stop API
- use `AudioPlayerService` in `MeditationSetupView`
- use `AudioPlayerService` in `MeditationViewModel`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68563f0d4c308331ab806589e48c9ff2