### PR TITLE
Enable offline journal caching and sync

### DIFF
--- a/meditation/Services/LocalJournalStore.swift
+++ b/meditation/Services/LocalJournalStore.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+struct PendingJournalAction: Codable {
+    enum ActionType: String, Codable {
+        case add
+        case update
+        case delete
+    }
+
+    let type: ActionType
+    let entry: JournalEntry
+}
+
+class LocalJournalStore {
+    static let shared = LocalJournalStore()
+
+    private let entriesURL: URL
+    private let pendingURL: URL
+
+    private init() {
+        let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        entriesURL = dir.appendingPathComponent("journal_entries.json")
+        pendingURL = dir.appendingPathComponent("pending_journal_actions.json")
+    }
+
+    // MARK: - Entries
+    func loadEntries() -> [JournalEntry] {
+        guard let data = try? Data(contentsOf: entriesURL) else { return [] }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return (try? decoder.decode([JournalEntry].self, from: data)) ?? []
+    }
+
+    func saveEntries(_ entries: [JournalEntry]) {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        if let data = try? encoder.encode(entries) {
+            try? data.write(to: entriesURL)
+        }
+    }
+
+    // MARK: - Pending Actions
+    func loadPendingActions() -> [PendingJournalAction] {
+        guard let data = try? Data(contentsOf: pendingURL) else { return [] }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return (try? decoder.decode([PendingJournalAction].self, from: data)) ?? []
+    }
+
+    func savePendingActions(_ actions: [PendingJournalAction]) {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        if let data = try? encoder.encode(actions) {
+            try? data.write(to: pendingURL)
+        }
+    }
+
+    func addPendingAction(_ action: PendingJournalAction) {
+        var actions = loadPendingActions()
+        actions.append(action)
+        savePendingActions(actions)
+    }
+
+    func removePendingAction(id: String, type: PendingJournalAction.ActionType) {
+        var actions = loadPendingActions()
+        actions.removeAll { $0.entry.id == id && $0.type == type }
+        savePendingActions(actions)
+    }
+
+    // Convenience operations on entries
+    func addEntry(_ entry: JournalEntry) {
+        var entries = loadEntries()
+        entries.append(entry)
+        saveEntries(entries)
+    }
+
+    func updateEntry(_ entry: JournalEntry) {
+        var entries = loadEntries()
+        if let index = entries.firstIndex(where: { $0.id == entry.id }) {
+            entries[index] = entry
+            saveEntries(entries)
+        }
+    }
+
+    func deleteEntry(id: String) {
+        var entries = loadEntries()
+        entries.removeAll { $0.id == id }
+        saveEntries(entries)
+    }
+}

--- a/meditation/ViewModels/JournalViewModel.swift
+++ b/meditation/ViewModels/JournalViewModel.swift
@@ -1,12 +1,20 @@
 import Foundation
 import FirebaseFirestore
 import FirebaseAuth
+import Network
 
 class JournalViewModel: ObservableObject {
     @Published var entries: [JournalEntry] = []
 
     private let db = Firestore.firestore()
     private var listener: ListenerRegistration?
+    private let store = LocalJournalStore.shared
+    private let monitor = NWPathMonitor()
+    private var isConnected: Bool = true
+
+    init() {
+        startNetworkMonitor()
+    }
     
     // MARK: - 감정 일기 저장
     func saveJournal(mood: String, text: String, durationMinutes: Int, completion: @escaping (Result<Void, Error>) -> Void) {
@@ -14,27 +22,38 @@ class JournalViewModel: ObservableObject {
             completion(.failure(NSError(domain: "auth", code: 401, userInfo: [NSLocalizedDescriptionKey: "로그인 상태가 아닙니다."])))
             return
         }
-        
+
         let entry = JournalEntry(
             mood: mood,
             text: text,
             durationMinutes: durationMinutes,
             date: Date()
         )
-        
+
+        store.addEntry(entry)
+        entries.insert(entry, at: 0)
+
+        guard isConnected else {
+            store.addPendingAction(PendingJournalAction(type: .add, entry: entry))
+            completion(.success(()))
+            return
+        }
+
         do {
             let data = try Firestore.Encoder().encode(entry)
             db.collection("users").document(userId)
                 .collection("journals")
                 .document(entry.id)
-                .setData(data) { error in
+                .setData(data) { [weak self] error in
                     if let error = error {
+                        self?.store.addPendingAction(PendingJournalAction(type: .add, entry: entry))
                         completion(.failure(error))
                     } else {
                         completion(.success(()))
                     }
                 }
         } catch {
+            store.addPendingAction(PendingJournalAction(type: .add, entry: entry))
             completion(.failure(error))
         }
     }
@@ -54,19 +73,32 @@ class JournalViewModel: ObservableObject {
             date: entry.date
         )
 
+        store.updateEntry(updated)
+        if let index = entries.firstIndex(where: { $0.id == updated.id }) {
+            entries[index] = updated
+        }
+
+        guard isConnected else {
+            store.addPendingAction(PendingJournalAction(type: .update, entry: updated))
+            completion(.success(()))
+            return
+        }
+
         do {
             let data = try Firestore.Encoder().encode(updated)
             db.collection("users").document(userId)
                 .collection("journals")
                 .document(entry.id)
-                .setData(data) { error in
+                .setData(data) { [weak self] error in
                     if let error = error {
+                        self?.store.addPendingAction(PendingJournalAction(type: .update, entry: updated))
                         completion(.failure(error))
                     } else {
                         completion(.success(()))
                     }
                 }
         } catch {
+            store.addPendingAction(PendingJournalAction(type: .update, entry: updated))
             completion(.failure(error))
         }
     }
@@ -78,11 +110,21 @@ class JournalViewModel: ObservableObject {
             return
         }
 
+        store.deleteEntry(id: entry.id)
+        entries.removeAll { $0.id == entry.id }
+
+        guard isConnected else {
+            store.addPendingAction(PendingJournalAction(type: .delete, entry: entry))
+            completion(.success(()))
+            return
+        }
+
         db.collection("users").document(userId)
             .collection("journals")
             .document(entry.id)
-            .delete { error in
+            .delete { [weak self] error in
                 if let error = error {
+                    self?.store.addPendingAction(PendingJournalAction(type: .delete, entry: entry))
                     completion(.failure(error))
                 } else {
                     completion(.success(()))
@@ -94,6 +136,11 @@ class JournalViewModel: ObservableObject {
     func fetchJournals() {
         guard let userId = Auth.auth().currentUser?.uid else { return }
 
+        guard isConnected else {
+            entries = store.loadEntries().sorted { $0.date > $1.date }
+            return
+        }
+
         listener = db.collection("users").document(userId)
             .collection("journals")
             .order(by: "date", descending: true)
@@ -102,6 +149,7 @@ class JournalViewModel: ObservableObject {
                     self.entries = documents.compactMap { doc in
                         try? doc.data(as: JournalEntry.self)
                     }
+                    self.store.saveEntries(self.entries)
                 }
             }
     }
@@ -109,5 +157,53 @@ class JournalViewModel: ObservableObject {
     func removeListener() {
         listener?.remove()
         listener = nil
+    }
+
+    // MARK: - Network Monitoring
+    private func startNetworkMonitor() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            DispatchQueue.main.async {
+                let connected = path.status == .satisfied
+                if connected && self?.isConnected == false {
+                    self?.syncPendingActions()
+                }
+                self?.isConnected = connected
+            }
+        }
+        monitor.start(queue: DispatchQueue(label: "NetworkMonitor"))
+    }
+
+    private func syncPendingActions() {
+        guard let userId = Auth.auth().currentUser?.uid else { return }
+        var actions = store.loadPendingActions()
+        guard !actions.isEmpty else { return }
+
+        for action in actions {
+            switch action.type {
+            case .add, .update:
+                do {
+                    let data = try Firestore.Encoder().encode(action.entry)
+                    db.collection("users").document(userId)
+                        .collection("journals")
+                        .document(action.entry.id)
+                        .setData(data) { [weak self] error in
+                            if error == nil {
+                                self?.store.removePendingAction(id: action.entry.id, type: action.type)
+                            }
+                        }
+                } catch {
+                    continue
+                }
+            case .delete:
+                db.collection("users").document(userId)
+                    .collection("journals")
+                    .document(action.entry.id)
+                    .delete { [weak self] error in
+                        if error == nil {
+                            self?.store.removePendingAction(id: action.entry.id, type: action.type)
+                        }
+                    }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `LocalJournalStore` for storing journals and pending operations
- sync local data with Firestore once connection is restored
- update `JournalViewModel` to read/write local cache and handle connectivity

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68563f0f46f88331906e5006261e1a1b