### PR TITLE
Fix Stats fetch on tab activation

### DIFF
--- a/meditation/Views/Stats/StatsTabView.swift
+++ b/meditation/Views/Stats/StatsTabView.swift
@@ -77,6 +77,9 @@ struct StatsTabView: View {
                 Spacer()
             }
         }
+        .onAppear {
+            viewModel.fetchStats()
+        }
         .background(Color.white.ignoresSafeArea())
     }
 }


### PR DESCRIPTION
## Summary
- refresh stats data whenever the Stats tab appears

## Testing
- `swift test -v` *(fails: Package.swift missing)*
- `xcodebuild -list -project Meditation.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856462e9e5c8331892b1c4ea9c921df