### PR TITLE
Fix timer cleanup on meditation exit

### DIFF
--- a/meditation/Views/Meditation/MeditationStartView.swift
+++ b/meditation/Views/Meditation/MeditationStartView.swift
@@ -54,6 +54,9 @@ struct MeditationStartView: View {
             .padding()
         }
         .onAppear(perform: startMeditation)
+        .onDisappear {
+            endMeditation()
+        }
     }
 
     private func startMeditation() {


### PR DESCRIPTION
## Summary
- stop the meditation timer and audio when `MeditationStartView` disappears

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project Meditation.xcodeproj -scheme Meditation -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856463347b483319af8fa73e7a41be8