### PR TITLE
Track meditation duration

### DIFF
--- a/meditation/App/AppRootView.swift
+++ b/meditation/App/AppRootView.swift
@@ -47,8 +47,8 @@ struct AppRootView: View {
                 durationMinutes: duration,
                 mood: mood,
                 music: music,
-                onFinish: {
-                    appState.navigate(to: .meditationSummary(duration: duration, mood: mood))
+                onFinish: { actualDuration in
+                    appState.navigate(to: .meditationSummary(duration: actualDuration, mood: mood))
                 }
             )
 


### PR DESCRIPTION
## Summary
- compute elapsed time in `MeditationStartView` and pass it via `onFinish`
- route to meditation summary with actual duration

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6856463489088331a82ef8a3d55afd5f