### PR TITLE
Configure audio session before playback

### DIFF
--- a/meditation/Services/AudioPlayerService.swift
+++ b/meditation/Services/AudioPlayerService.swift
@@ -14,6 +14,10 @@ final class AudioPlayerService {
             return
         }
         do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playback, mode: .default)
+            try session.setActive(true)
+
             player = try AVAudioPlayer(contentsOf: url)
             player?.numberOfLoops = loop ? -1 : 0
             player?.play()


### PR DESCRIPTION
## Summary
- ensure `AVAudioSession` is set before creating `AVAudioPlayer`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68564635642083318c83221deafad8c9