### PR TITLE
Improve stats tab UI

### DIFF
--- a/meditation/Views/Stats/StatsTabView.swift
+++ b/meditation/Views/Stats/StatsTabView.swift
@@ -14,24 +14,39 @@ struct StatsTabView: View {
 
                 // 총 명상 시간
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("누적 명상 시간")
-                        .font(.headline)
-                        .foregroundColor(.secondary)
+                    Label {
+                        Text("누적 명상 시간")
+                    } icon: {
+                        Image(systemName: "clock.fill")
+                    }
+                    .font(.headline)
+                    .foregroundColor(.secondary)
 
                     Text("\(viewModel.totalMinutes)분")
                         .font(.system(size: 36, weight: .bold))
-                        .foregroundColor(Color("SoftBlue"))
+                        .foregroundColor(.white)
                 }
                 .padding()
-                .background(Color("SoftBlue").opacity(0.1))
-                .cornerRadius(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    LinearGradient(
+                        colors: [Color("SoftBlue"), Color("DeepIndigo")],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
                 .padding(.horizontal)
 
                 // 감정별 분포 차트
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("감정별 분포")
-                        .font(.headline)
-                        .padding(.horizontal)
+                    Label {
+                        Text("감정별 분포")
+                    } icon: {
+                        Image(systemName: "chart.bar.fill")
+                    }
+                    .font(.headline)
+                    .padding(.horizontal)
 
                     if viewModel.moodCount.isEmpty {
                         Text("아직 기록된 감정이 없습니다.")
@@ -51,28 +66,44 @@ struct StatsTabView: View {
                         .padding(.horizontal)
                     }
                 }
+                .padding()
+                .background(.thinMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .padding(.horizontal)
 
                 // 주간 명상 목표 달성률
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("주간 명상 목표")
-                        .font(.headline)
-                        .padding(.horizontal)
+                    Label {
+                        Text("주간 명상 목표")
+                    } icon: {
+                        Image(systemName: "chart.line.uptrend.xyaxis")
+                    }
+                    .font(.headline)
+                    .padding(.horizontal)
 
-                    HStack(spacing: 12) {
-                        ForEach(Calendar.current.weekdaySymbols, id: \.self) { day in
-                            VStack(spacing: 4) {
-                                Text(String(day.prefix(1))) // 요일 첫 글자
-                                    .font(.caption2)
-                                    .foregroundColor(.secondary)
+                    let progressData = Calendar.current.weekdaySymbols.map { day in
+                        (day: day, value: viewModel.weeklyStats[day] == true ? 1 : 0)
+                    }
 
-                                Circle()
-                                    .fill(viewModel.weeklyStats[day] == true ? Color("Lavender") : Color.gray.opacity(0.3))
-                                    .frame(width: 16, height: 16)
-                            }
+                    Chart {
+                        ForEach(progressData, id: \.day) { item in
+                            LineMark(
+                                x: .value("Day", item.day),
+                                y: .value("완료", item.value)
+                            )
+                            PointMark(
+                                x: .value("Day", item.day),
+                                y: .value("완료", item.value)
+                            )
                         }
                     }
+                    .frame(height: 160)
                     .padding(.horizontal)
                 }
+                .padding()
+                .background(.thinMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .padding(.horizontal)
 
                 Spacer()
             }


### PR DESCRIPTION
## Summary
- restyle total meditation time with gradient card and clock icon
- use SF Symbols for section headers
- show weekly progress as a line chart
- apply thin material cards for charts

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6856508f88548331ae8d45f0d0528712