### PR TITLE
Delay stats fetch until StatsTabView appears

### DIFF
--- a/meditation/ViewModels/StatsViewModel.swift
+++ b/meditation/ViewModels/StatsViewModel.swift
@@ -12,7 +12,7 @@ class StatsViewModel: ObservableObject {
     private let db = Firestore.firestore()
 
     init() {
-        fetchStats()
+        // Intentionally left blank; fetchStats() should be called explicitly
     }
 
     func fetchStats() {


### PR DESCRIPTION
## Summary
- avoid automatically fetching statistics when `StatsViewModel` initializes
- keep loading stats in `StatsTabView` via `onAppear`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68565090bc2c8331a0447c913ad66900