### PR TITLE
Display Stats errors

### DIFF
--- a/meditation/Views/Stats/StatsTabView.swift
+++ b/meditation/Views/Stats/StatsTabView.swift
@@ -12,6 +12,13 @@ struct StatsTabView: View {
                     .padding(.top)
                     .padding(.horizontal)
 
+                if viewModel.hasError, let error = viewModel.errorMessage {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .padding(.horizontal)
+                }
+
                 // 총 명상 시간
                 VStack(alignment: .leading, spacing: 8) {
                     Text("누적 명상 시간")


### PR DESCRIPTION
## Summary
- present StatsViewModel error messages in StatsTabView so users see network failures

## Testing
- `swift test` *(fails: Package.swift missing)*

------
https://chatgpt.com/codex/tasks/task_e_68565091bdfc8331885dab2c85f6a24c