### PR TITLE
Store mood id in journal entries

### DIFF
--- a/meditation/Models/Mood.swift
+++ b/meditation/Models/Mood.swift
@@ -19,4 +19,9 @@ struct Mood: Identifiable, Equatable, Hashable {
     static func mood(for id: String) -> Mood? {
         sampleMoods.first { $0.id == id }
     }
+
+    /// Looks up the mood identifier for a given display name.
+    static func id(forName name: String) -> String? {
+        sampleMoods.first { $0.name == name }?.id
+    }
 }

--- a/meditation/ViewModels/StatsViewModel.swift
+++ b/meditation/ViewModels/StatsViewModel.swift
@@ -41,7 +41,18 @@ class StatsViewModel: ObservableObject {
                 let calendar = Calendar.current
 
                 for doc in documents {
-                    if let entry = try? doc.data(as: JournalEntry.self) {
+                    if var entry = try? doc.data(as: JournalEntry.self) {
+                        if Mood.mood(for: entry.mood) == nil,
+                           let id = Mood.id(forName: entry.mood) {
+                            entry = JournalEntry(
+                                id: entry.id,
+                                mood: id,
+                                text: entry.text,
+                                durationMinutes: entry.durationMinutes,
+                                date: entry.date
+                            )
+                            try? doc.reference.setData(from: entry)
+                        }
                         moodDict[entry.mood, default: 0] += 1
                         minutesSum += entry.durationMinutes
 

--- a/meditation/Views/Journal/HistoryTabView.swift
+++ b/meditation/Views/Journal/HistoryTabView.swift
@@ -81,7 +81,7 @@ struct HistoryTabView: View {
     }
 
     private func addEntry() {
-        let mood = Mood.sampleMoods.first?.name ?? ""
+        let mood = Mood.sampleMoods.first?.id ?? ""
         let newEntry = JournalEntry(
             mood: mood,
             text: "",

--- a/meditation/Views/Meditation/MeditationSummaryView.swift
+++ b/meditation/Views/Meditation/MeditationSummaryView.swift
@@ -66,7 +66,7 @@ struct MeditationSummaryView: View {
 
     private func saveEntry() {
         isSaving = true
-        journalViewModel.saveJournal(mood: mood.name, text: memo, durationMinutes: durationMinutes) { result in
+        journalViewModel.saveJournal(mood: mood.id, text: memo, durationMinutes: durationMinutes) { result in
             DispatchQueue.main.async {
                 isSaving = false
                 switch result {

--- a/meditation/Views/Stats/StatsTabView.swift
+++ b/meditation/Views/Stats/StatsTabView.swift
@@ -39,12 +39,13 @@ struct StatsTabView: View {
                             .padding(.horizontal)
                     } else {
                         Chart {
-                            ForEach(viewModel.moodCount.sorted(by: { $0.key < $1.key }), id: \.key) { mood, count in
+                            ForEach(viewModel.moodCount.sorted(by: { $0.key < $1.key }), id: \.key) { moodId, count in
+                                let moodName = Mood.mood(for: moodId)?.name ?? moodId
                                 BarMark(
-                                    x: .value("감정", mood),
+                                    x: .value("감정", moodName),
                                     y: .value("횟수", count)
                                 )
-                                .foregroundStyle(by: .value("감정", mood))
+                                .foregroundStyle(by: .value("감정", moodName))
                             }
                         }
                         .frame(height: 200)


### PR DESCRIPTION
## Summary
- save mood identifiers instead of names when storing meditation entries
- migrate existing journal data from mood names to identifiers
- display mood names from identifiers when showing stats

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6856509266e88331b272e597da2ccf60