### PR TITLE
Fix unmatched brace in HistoryTabView

### DIFF
--- a/meditation/Views/Journal/HistoryTabView.swift
+++ b/meditation/Views/Journal/HistoryTabView.swift
@@ -126,3 +126,4 @@ struct HistoryTabView: View {
         appState.navigate(to: .journalEditor(entry: newEntry))
     }
 }
+}


### PR DESCRIPTION
## Summary
- close the HistoryTabView struct properly by adding the missing `}`

## Testing
- `xcodebuild -list -project Meditation.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68564d30f78c8331b40c1f9920501b07