### PR TITLE
Fix HistoryTabView body closure

### DIFF
--- a/meditation/Views/Journal/HistoryTabView.swift
+++ b/meditation/Views/Journal/HistoryTabView.swift
@@ -115,6 +115,8 @@ struct HistoryTabView: View {
         }
     }
 
+    }
+
     private func addEntry() {
         let mood = Mood.sampleMoods.first?.id ?? ""
         let newEntry = JournalEntry(
@@ -125,5 +127,4 @@ struct HistoryTabView: View {
         )
         appState.navigate(to: .journalEditor(entry: newEntry))
     }
-}
 }


### PR DESCRIPTION
## Summary
- close the HistoryTabView body before declaring addEntry

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685655934e588331866f26fcbc56b26e