### PR TITLE
Update pastel colors and profile UI

### DIFF
--- a/meditation/Resources/Assets.xcassets/PastelMint.colorset/Contents.json
+++ b/meditation/Resources/Assets.xcassets/PastelMint.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE8",
+          "green" : "0xFF",
+          "red" : "0xD1"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/meditation/Resources/Assets.xcassets/PastelPink.colorset/Contents.json
+++ b/meditation/Resources/Assets.xcassets/PastelPink.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCC",
+          "green" : "0xC1",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/meditation/Resources/Assets.xcassets/PastelPurple.colorset/Contents.json
+++ b/meditation/Resources/Assets.xcassets/PastelPurple.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE0",
+          "green" : "0xC6",
+          "red" : "0xDC"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/meditation/Views/Journal/HistoryTabView.swift
+++ b/meditation/Views/Journal/HistoryTabView.swift
@@ -97,7 +97,7 @@ struct HistoryTabView: View {
                 }
                 .padding(.top)
         }
-        .background(Color("SoftGray").ignoresSafeArea())
+        .background(Color("PastelMint").ignoresSafeArea())
         .searchable(text: $searchText, prompt: "검색")
         .navigationTitle("감정 일지")
         .toolbar {

--- a/meditation/Views/Profile/ProfileTabView.swift
+++ b/meditation/Views/Profile/ProfileTabView.swift
@@ -6,44 +6,53 @@ struct ProfileTabView: View {
     @State private var userEmail: String = Auth.auth().currentUser?.email ?? "Unknown"
     
     var body: some View {
-        VStack(spacing: 32) {
-                // 사용자 이메일 표시
-                VStack(spacing: 4) {
-                    Text("Logged in as")
-                        .font(.caption)
-                        .foregroundColor(.gray)
-                    Text(userEmail)
-                        .font(.headline)
-                        .foregroundColor(.primary)
-                }
+        VStack(spacing: 24) {
+            // 헤더 프로필 이미지와 이메일
+            VStack(spacing: 8) {
+                Image(systemName: "person.crop.circle.fill")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 80, height: 80)
+                    .foregroundStyle(
+                        LinearGradient(colors: [Color("SoftGreen"), Color("SoftBlue")], startPoint: .top, endPoint: .bottom)
+                    )
 
-                // 로그아웃 버튼
-                Button(action: {
-                    logout()
-                }) {
-                    Text("로그아웃")
-                        .font(.headline)
-                        .foregroundColor(.white)
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.red)
-                        .cornerRadius(12)
-                        .padding(.horizontal)
-                }
+                Text(userEmail)
+                    .font(.headline)
+            }
+            .padding()
+            .frame(maxWidth: .infinity)
+            .background(.thinMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .padding(.horizontal)
 
-                // 앱 정보 표시
-                VStack(spacing: 4) {
-                    Text("앱 버전 \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "-")")
-                        .font(.footnote)
-                        .foregroundColor(.gray)
-                    Text("© 2025 Soomgyeol")
-                        .font(.footnote)
-                        .foregroundColor(.gray)
-                }
+            // 로그아웃 버튼
+            Button(action: logout) {
+                Text("로그아웃")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(
+                        LinearGradient(colors: [Color("SoftBlue"), Color("DeepIndigo")], startPoint: .topLeading, endPoint: .bottomTrailing)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            }
+            .padding(.horizontal)
 
-                Spacer()
+            // 앱 정보 표시
+            VStack(spacing: 4) {
+                Text("앱 버전 \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "-")")
+                    .font(.footnote)
+                    .foregroundColor(.gray)
+                Text("© 2025 Soomgyeol")
+                    .font(.footnote)
+                    .foregroundColor(.gray)
+            }
+
+            Spacer()
         }
-        .padding(.top, 60)
+        .padding(.top, 40)
         .navigationTitle("프로필")
     }
 

--- a/meditation/Views/Stats/StatsTabView.swift
+++ b/meditation/Views/Stats/StatsTabView.swift
@@ -37,7 +37,7 @@ struct StatsTabView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(
                     LinearGradient(
-                        colors: [Color("SoftBlue"), Color("DeepIndigo")],
+                        colors: [Color("PastelPink"), Color("PastelPurple")],
                         startPoint: .topLeading,
                         endPoint: .bottomTrailing
                     )


### PR DESCRIPTION
## Summary
- add new pastel color assets
- use `PastelMint` background in History view
- apply a pastel pink-purple gradient in Stats view
- redesign profile screen with a gradient avatar and button

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68565b4f5d7883318808c16d2d109971