### PR TITLE
Sync history background with selected mood

### DIFF
--- a/meditation/App/AppState.swift
+++ b/meditation/App/AppState.swift
@@ -4,6 +4,8 @@ import FirebaseAuth
 class AppState: ObservableObject {
     @Published var path: [Route] = []
     @Published var isLoggedIn: Bool = false
+    /// Currently selected mood color to sync backgrounds across tabs.
+    @Published var currentMoodColor: String? = nil
 
     private var authListenerHandle: AuthStateDidChangeListenerHandle?
 

--- a/meditation/Views/Home/HomeTabView.swift
+++ b/meditation/Views/Home/HomeTabView.swift
@@ -11,8 +11,12 @@ struct HomeTabView: View {
     ]
 
     var body: some View {
-        ScrollView {
-            VStack(spacing: 24) {
+        ZStack {
+            Color(appState.currentMoodColor ?? "SoftGray")
+                .ignoresSafeArea()
+
+            ScrollView {
+                VStack(spacing: 24) {
                 DailyQuoteView()
                     .padding(.top)
 
@@ -28,6 +32,7 @@ struct HomeTabView: View {
                         MoodCardView(mood: mood, isSelected: isSelected)
                             .onTapGesture {
                                 selectedMood = mood
+                                appState.currentMoodColor = mood.colorName
                             }
                     }
                 }
@@ -52,8 +57,12 @@ struct HomeTabView: View {
                 }
                 }
                 .padding(.vertical)
+            }
+            .background(
+                Color(appState.currentMoodColor ?? "SoftGray")
+                    .brightness(-0.1)
+            )
         }
-        .background(Color(selectedMood?.colorName ?? "SoftGray").opacity(0.15)) // ✅ 수정
         .ignoresSafeArea(edges: .bottom)
     }
 }

--- a/meditation/Views/Journal/HistoryTabView.swift
+++ b/meditation/Views/Journal/HistoryTabView.swift
@@ -29,8 +29,12 @@ struct HistoryTabView: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(spacing: 12) {
+        ZStack {
+            Color(appState.currentMoodColor ?? "PastelMint")
+                .ignoresSafeArea()
+
+            ScrollView {
+                VStack(spacing: 12) {
                 Picker("감정 필터", selection: $selectedMoodID) {
                     Text("전체").tag(String?.none)
                     ForEach(Mood.sampleMoods) { mood in
@@ -96,8 +100,13 @@ struct HistoryTabView: View {
                     }
                 }
                 .padding(.top)
+            }
+            .background(
+                Color(appState.currentMoodColor ?? "PastelMint")
+                    .brightness(-0.1)
+            )
         }
-        .background(Color("PastelMint").ignoresSafeArea())
+        .background(Color.clear) // base color handled by ZStack
         .searchable(text: $searchText, prompt: "검색")
         .navigationTitle("감정 일지")
         .toolbar {
@@ -113,8 +122,6 @@ struct HistoryTabView: View {
         .onDisappear {
             viewModel.removeListener()
         }
-    }
-
     }
 
     private func addEntry() {


### PR DESCRIPTION
## Summary
- store selected mood color in `AppState`
- apply shared color in `HomeTabView` and `HistoryTabView`
- darken scroll backgrounds for a two-tone effect
- fix extra bracket in History view

## Testing
- `swift test` *(fails: Could not find Package.swift)*


------
https://chatgpt.com/codex/tasks/task_e_68566083d1f083319bdce783312a8036