### PR TITLE
Adjust history background for mood-based two-tone layout

### DIFF
--- a/meditation/Views/Journal/HistoryTabView.swift
+++ b/meditation/Views/Journal/HistoryTabView.swift
@@ -31,6 +31,7 @@ struct HistoryTabView: View {
     var body: some View {
         ZStack {
             Color(appState.currentMoodColor ?? "PastelMint")
+                .brightness(0.1)
                 .ignoresSafeArea()
 
             ScrollView {
@@ -106,7 +107,7 @@ struct HistoryTabView: View {
                     .brightness(-0.1)
             )
         }
-        .background(Color.clear) // base color handled by ZStack
+        .ignoresSafeArea(edges: .bottom)
         .searchable(text: $searchText, prompt: "검색")
         .navigationTitle("감정 일지")
         .toolbar {


### PR DESCRIPTION
## Summary
- align `HistoryTabView` background behavior with `HomeTabView`
- lighten the base mood color and darken only the scroll view
- allow color to extend underneath the tab bar

## Testing
- `swift test` *(fails: Package.swift missing)*
- `xcodebuild test -scheme Meditation` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68566d98b68083318fda2967cc7ae2e4