### PR TITLE
Fix unmatched brace in HistoryTabView

### DIFF
--- a/meditation/Views/Journal/HistoryTabView.swift
+++ b/meditation/Views/Journal/HistoryTabView.swift
@@ -136,3 +136,4 @@ struct HistoryTabView: View {
         appState.navigate(to: .journalEditor(entry: newEntry))
     }
 }
+}


### PR DESCRIPTION
## Summary
- close `HistoryTabView` struct properly

## Testing
- `swift --version`
- `xcodebuild -version` *(fails: command not found)*
- `swift test` *(fails: no Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68566e99422c83319286cb93c4354a99