### PR TITLE
Add mood-based background for HistoryTabView

### DIFF
--- a/meditation/Views/Journal/HistoryTabView.swift
+++ b/meditation/Views/Journal/HistoryTabView.swift
@@ -8,6 +8,12 @@ struct HistoryTabView: View {
     /// Optional mood identifier used to limit results to a specific mood.
     @State private var selectedMoodID: String?
 
+    /// Currently selected mood based on `selectedMoodID`.
+    private var selectedMood: Mood? {
+        guard let id = selectedMoodID else { return nil }
+        return Mood.mood(for: id)
+    }
+
     /// Filtered list of journal entries matching the current search criteria.
     private var filteredEntries: [JournalEntry] {
         viewModel.entries.filter { entry in
@@ -97,7 +103,8 @@ struct HistoryTabView: View {
                 }
                 .padding(.top)
         }
-        .background(Color("PastelMint").ignoresSafeArea())
+        .background(Color(selectedMood?.colorName ?? "PastelMint").opacity(0.15))
+        .ignoresSafeArea()
         .searchable(text: $searchText, prompt: "검색")
         .navigationTitle("감정 일지")
         .toolbar {


### PR DESCRIPTION
## Summary
- include a computed `selectedMood` in `HistoryTabView`
- switch HistoryTabView background color based on the current mood filter

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685691a5405c8331be1de933b62490e1