### PR TITLE
Add login and signup routes

### DIFF
--- a/meditation/App/AppRootView.swift
+++ b/meditation/App/AppRootView.swift
@@ -27,6 +27,12 @@ struct AppRootView: View {
         case .launch:
             LaunchView(navigate: appState.navigate)
 
+        case .login:
+            LoginView(navigate: appState.navigate)
+
+        case .signup:
+            SignupView(navigate: appState.navigate)
+
         case .home:
             MainTabView()
 

--- a/meditation/App/Route.swift
+++ b/meditation/App/Route.swift
@@ -2,6 +2,8 @@ import Foundation
 
 enum Route: Hashable {
     case launch
+    case login
+    case signup
     case home
     case content(Mood)
     case meditationSetup(Mood)

--- a/meditation/Views/Auth/LoginView.swift
+++ b/meditation/Views/Auth/LoginView.swift
@@ -47,7 +47,7 @@ struct LoginView: View {
                 }
 
                 Button("회원가입") {
-                    navigate(.profile) // Placeholder: navigate to signup route
+                    navigate(.signup)
                 }
                 .foregroundColor(.gray)
             }

--- a/meditation/Views/Launch/LaunchView.swift
+++ b/meditation/Views/Launch/LaunchView.swift
@@ -1,14 +1,12 @@
 import SwiftUI
 
 struct LaunchView: View {
-    @StateObject private var authViewModel = AuthViewModel()
     let navigate: (Route) -> Void
 
     var body: some View {
         VStack(spacing: 28) {
             Spacer()
 
-            // 앱 로고 및 이름
             VStack(spacing: 12) {
                 Image(systemName: "leaf.circle.fill")
                     .resizable()
@@ -20,62 +18,18 @@ struct LaunchView: View {
                     .foregroundColor(.primary)
             }
 
-            // 이메일 입력
             VStack(spacing: 12) {
-                TextField("Email", text: $authViewModel.email)
-                    .keyboardType(.emailAddress)
-                    .autocapitalization(.none)
-                    .padding()
-                    .background(Color(.secondarySystemBackground))
-                    .cornerRadius(12)
-
-                SecureField("Password", text: $authViewModel.password)
-                    .padding()
-                    .background(Color(.secondarySystemBackground))
-                    .cornerRadius(12)
-            }
-            .padding(.horizontal)
-
-            // 에러 메시지
-            if let error = authViewModel.errorMessage {
-                Text(error)
-                    .font(.caption)
-                    .foregroundColor(.red)
-            }
-
-            // 로그인 / 회원가입 버튼
-            VStack(spacing: 12) {
-                Button(action: {
-                    authViewModel.signIn {
-                        navigate(.home)
-                    }
-                }) {
-                    Text("로그인")
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.green)
-                        .foregroundColor(.white)
-                        .cornerRadius(12)
+                RoundedButton(title: "로그인", backgroundColor: .green) {
+                    navigate(.login)
                 }
 
-                Button(action: {
-                    authViewModel.signUp {
-                        navigate(.home)
-                    }
-                }) {
-                    Text("회원가입")
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.gray.opacity(0.2))
-                        .foregroundColor(.primary)
-                        .cornerRadius(12)
+                RoundedButton(
+                    title: "회원가입",
+                    backgroundColor: .gray.opacity(0.2),
+                    textColor: .primary
+                ) {
+                    navigate(.signup)
                 }
-
-                Button("게스트로 시작") {
-                    navigate(.home)
-                }
-                .font(.footnote)
-                .foregroundColor(.gray)
             }
             .padding(.horizontal)
 


### PR DESCRIPTION
## Summary
- handle login and signup in `Route`
- show `LoginView` and `SignupView` when those routes are chosen
- simplify `LaunchView` to show buttons for login and signup
- link from LoginView to signup screen

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68569bb361908331884ff60a5989d8e6