### PR TITLE
Implement user model and update auth

### DIFF
--- a/meditation/App/AppState.swift
+++ b/meditation/App/AppState.swift
@@ -4,19 +4,29 @@ import FirebaseAuth
 class AppState: ObservableObject {
     @Published var path: [Route] = []
     @Published var isLoggedIn: Bool = false
+    @Published var user: User?
 
     private var authListenerHandle: AuthStateDidChangeListenerHandle?
 
     init() {
-        isLoggedIn = Auth.auth().currentUser != nil
+        if let current = Auth.auth().currentUser {
+            user = User(firebaseUser: current)
+            isLoggedIn = true
+        } else {
+            isLoggedIn = false
+        }
         observeAuthChanges()
     }
 
     private func observeAuthChanges() {
         authListenerHandle = Auth.auth().addStateDidChangeListener { [weak self] _, user in
             DispatchQueue.main.async {
-                self?.isLoggedIn = (user != nil)
-                if user == nil {
+                if let user = user {
+                    self?.user = User(firebaseUser: user)
+                    self?.isLoggedIn = true
+                } else {
+                    self?.isLoggedIn = false
+                    self?.user = nil
                     self?.path = []
                 }
             }

--- a/meditation/Models/User.swift
+++ b/meditation/Models/User.swift
@@ -6,3 +6,34 @@
 //
 
 import Foundation
+import FirebaseAuth
+
+/// Represents an authenticated application user.
+struct User: Identifiable {
+    /// Unique identifier for the user (Firebase UID).
+    let id: String
+
+    /// Display name shown in the UI. Falls back to the user's email when no
+    /// explicit display name is available.
+    let displayName: String
+
+    /// Optional URL to the user's profile image.
+    let profileImageURL: URL?
+
+    init(id: String, displayName: String, profileImageURL: URL? = nil) {
+        self.id = id
+        self.displayName = displayName
+        self.profileImageURL = profileImageURL
+    }
+
+    /// Convenience initializer to create ``User`` from ``FirebaseAuth.User``.
+    init(firebaseUser: FirebaseAuth.User) {
+        id = firebaseUser.uid
+        if let name = firebaseUser.displayName, !name.isEmpty {
+            displayName = name
+        } else {
+            displayName = firebaseUser.email ?? firebaseUser.uid
+        }
+        profileImageURL = firebaseUser.photoURL
+    }
+}

--- a/meditation/Services/AuthService.swift
+++ b/meditation/Services/AuthService.swift
@@ -6,7 +6,7 @@ class AuthService {
 
     private init() {}
 
-    func signIn(email: String, password: String, completion: @escaping (Result<User, Error>) -> Void) {
+    func signIn(email: String, password: String, completion: @escaping (Result<FirebaseAuth.User, Error>) -> Void) {
         Auth.auth().signIn(withEmail: email, password: password) { result, error in
             if let error = error {
                 completion(.failure(error))
@@ -16,7 +16,7 @@ class AuthService {
         }
     }
 
-    func signUp(email: String, password: String, completion: @escaping (Result<User, Error>) -> Void) {
+    func signUp(email: String, password: String, completion: @escaping (Result<FirebaseAuth.User, Error>) -> Void) {
         Auth.auth().createUser(withEmail: email, password: password) { result, error in
             if let error = error {
                 completion(.failure(error))

--- a/meditation/ViewModels/AuthViewModel.swift
+++ b/meditation/ViewModels/AuthViewModel.swift
@@ -7,11 +7,12 @@ class AuthViewModel: ObservableObject {
     @Published var errorMessage: String?
     @Published var isAuthenticated = false
 
-    func signIn(completion: @escaping () -> Void) {
+    func signIn(appState: AppState, completion: @escaping () -> Void) {
         AuthService.shared.signIn(email: email, password: password) { result in
             DispatchQueue.main.async {
                 switch result {
-                case .success:
+                case .success(let firebaseUser):
+                    appState.user = User(firebaseUser: firebaseUser)
                     self.isAuthenticated = true
                     completion()
                 case .failure(let error):
@@ -21,11 +22,12 @@ class AuthViewModel: ObservableObject {
         }
     }
 
-    func signUp(completion: @escaping () -> Void) {
+    func signUp(appState: AppState, completion: @escaping () -> Void) {
         AuthService.shared.signUp(email: email, password: password) { result in
             DispatchQueue.main.async {
                 switch result {
-                case .success:
+                case .success(let firebaseUser):
+                    appState.user = User(firebaseUser: firebaseUser)
                     self.isAuthenticated = true
                     completion()
                 case .failure(let error):

--- a/meditation/Views/Auth/LoginView.swift
+++ b/meditation/Views/Auth/LoginView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct LoginView: View {
     @StateObject private var viewModel = AuthViewModel()
+    @EnvironmentObject var appState: AppState
     let navigate: (Route) -> Void
 
     var body: some View {
@@ -41,7 +42,7 @@ struct LoginView: View {
 
             VStack(spacing: 12) {
                 RoundedButton(title: "로그인", backgroundColor: .green) {
-                    viewModel.signIn {
+                    viewModel.signIn(appState: appState) {
                         navigate(.home)
                     }
                 }

--- a/meditation/Views/Auth/SignupView.swift
+++ b/meditation/Views/Auth/SignupView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SignupView: View {
     @StateObject private var viewModel = AuthViewModel()
+    @EnvironmentObject var appState: AppState
     let navigate: (Route) -> Void
 
     var body: some View {
@@ -41,7 +42,7 @@ struct SignupView: View {
 
             VStack(spacing: 12) {
                 RoundedButton(title: "회원가입", backgroundColor: .accentColor) {
-                    viewModel.signUp {
+                    viewModel.signUp(appState: appState) {
                         navigate(.home)
                     }
                 }

--- a/meditation/Views/Profile/ProfileTabView.swift
+++ b/meditation/Views/Profile/ProfileTabView.swift
@@ -3,21 +3,39 @@ import FirebaseAuth
 
 struct ProfileTabView: View {
     @EnvironmentObject var appState: AppState
-    @State private var userEmail: String = Auth.auth().currentUser?.email ?? "Unknown"
     
     var body: some View {
         VStack(spacing: 24) {
             // 헤더 프로필 이미지와 이메일
             VStack(spacing: 8) {
-                Image(systemName: "person.crop.circle.fill")
-                    .resizable()
-                    .scaledToFit()
+                if let url = appState.user?.profileImageURL {
+                    AsyncImage(url: url) { phase in
+                        if let image = phase.image {
+                            image
+                                .resizable()
+                                .scaledToFit()
+                        } else {
+                            Image(systemName: "person.crop.circle.fill")
+                                .resizable()
+                                .scaledToFit()
+                                .foregroundStyle(
+                                    LinearGradient(colors: [Color("SoftGreen"), Color("SoftBlue")], startPoint: .top, endPoint: .bottom)
+                                )
+                        }
+                    }
                     .frame(width: 80, height: 80)
-                    .foregroundStyle(
-                        LinearGradient(colors: [Color("SoftGreen"), Color("SoftBlue")], startPoint: .top, endPoint: .bottom)
-                    )
+                    .clipShape(Circle())
+                } else {
+                    Image(systemName: "person.crop.circle.fill")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 80, height: 80)
+                        .foregroundStyle(
+                            LinearGradient(colors: [Color("SoftGreen"), Color("SoftBlue")], startPoint: .top, endPoint: .bottom)
+                        )
+                }
 
-                Text(userEmail)
+                Text(appState.user?.displayName ?? "Unknown")
                     .font(.headline)
             }
             .padding()


### PR DESCRIPTION
## Summary
- create `User` struct describing logged in profile
- store current user in `AppState`
- return `FirebaseAuth.User` explicitly in `AuthService`
- record user info in `AuthViewModel`
- pass `AppState` into login and signup views
- show display name and profile image on the profile screen

## Testing
- `swiftc meditation/Models/User.swift` *(fails: no such module 'FirebaseAuth')*

------
https://chatgpt.com/codex/tasks/task_e_68569dd0ed0c83318cf802ecabc479c1