### PR TITLE
Implement guest mode and unify signup view

### DIFF
--- a/meditation/Views/Auth/SignupView.swift
+++ b/meditation/Views/Auth/SignupView.swift
@@ -10,10 +10,10 @@ struct SignupView: View {
             Spacer()
 
             VStack(spacing: 12) {
-                Image(systemName: "person.crop.circle.fill")
+                Image(systemName: "leaf.circle.fill")
                     .resizable()
                     .frame(width: 80, height: 80)
-                    .foregroundColor(.accentColor)
+                    .foregroundColor(.green)
 
                 Text("회원가입")
                     .font(.largeTitle.bold())
@@ -41,7 +41,7 @@ struct SignupView: View {
             }
 
             VStack(spacing: 12) {
-                RoundedButton(title: "회원가입", backgroundColor: .accentColor) {
+                RoundedButton(title: "회원가입", backgroundColor: .green) {
                     viewModel.signUp(appState: appState) {
                         navigate(.home)
                     }

--- a/meditation/Views/Launch/LaunchView.swift
+++ b/meditation/Views/Launch/LaunchView.swift
@@ -30,6 +30,14 @@ struct LaunchView: View {
                 ) {
                     navigate(.signup)
                 }
+
+                RoundedButton(
+                    title: "게스트 모드로 시작하기",
+                    backgroundColor: .gray.opacity(0.2),
+                    textColor: .primary
+                ) {
+                    navigate(.home)
+                }
             }
             .padding(.horizontal)
 


### PR DESCRIPTION
## Summary
- enable starting the app in guest mode from `LaunchView`
- align `SignupView` icon and button colors with the other screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856a89d5f78833184889d2227396015