### PR TITLE
Enhance meditation setup with trendy UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,29 @@
-# Meditation iOS Project
+# 🌿 숨결 Meditation 앱
 
-This repository contains the source code for a sample meditation iOS app.
+SwiftUI와 Firebase로 개발된 트렌디한 명상 앱입니다. 오늘의 기분을 선택하고, 음악과 함께 마음을 가다듬어 보세요.
 
-## Getting Started
+## 🚀 시작하기
+1. 이 저장소를 클론하거나 업데이트합니다.
+2. Xcode 15 이상에서 `Meditation.xcodeproj` 파일을 엽니다.
+3. 필요한 Swift 패키지는 자동으로 받아옵니다.
+4. **Meditation** 타겟을 빌드하고 실행합니다.
 
-1. Clone or pull the repository.
-2. Open `Meditation.xcodeproj` in Xcode (version 15 or later).
-3. Xcode will fetch Swift packages defined in `Package.resolved` automatically.
-4. Build and run the **Meditation** target.
+Firebase 설정 파일 `GoogleService-Info.plist`가 `meditation/` 디렉터리에 포함되어 있으니 별도 설정 없이 바로 사용할 수 있습니다.
 
-The Firebase configuration file `GoogleService-Info.plist` is located in the `meditation/` directory and is included in the project so the app can configure Firebase at launch.
+## ✨ 주요 기능
+- FirebaseAuth 기반 이메일 로그인/회원가입
+- 기분별 맞춤 명상 콘텐츠 제공
+- 명상 타이머와 배경 음악 재생 기능
+- 저널 기록 및 통계 확인
+- SwiftUI로 구현된 깔끔한 UI
+
+## 📂 프로젝트 구조
+```
+Meditation.xcodeproj/   Xcode 프로젝트 파일
+meditation/             앱 소스 코드와 리소스
+└── Services/           Firebase, 오디오 등 서비스 로직
+└── ViewModels/         화면별 상태 관리
+└── Views/              SwiftUI 화면 구성
+```
+
+트렌디한 명상 경험을 원한다면 지금 바로 **숨결**을 실행해 보세요!

--- a/meditation/Views/Meditation/MeditationSetupView.swift
+++ b/meditation/Views/Meditation/MeditationSetupView.swift
@@ -27,46 +27,60 @@ struct MeditationSetupView: View {
     private let musicOptions = MusicOption.all
 
     var body: some View {
-        VStack(spacing: 24) {
-            Spacer()
-
-            VStack {
-                Text("명상 시간: \(duration)분")
-                    .font(.title2)
-                Stepper("시간 선택", value: $duration, in: 1...60)
-            }
-            .padding()
-
-            VStack(alignment: .leading, spacing: 12) {
-                Text("배경 음악")
-                    .font(.title3)
-                Picker("음악", selection: $selectedMusic) {
-                    ForEach(musicOptions) { option in
-                        Text(option.displayName)
-                            .tag(option)
-                    }
+        ScrollView {
+            VStack(spacing: 32) {
+                VStack(spacing: 8) {
+                    Text(mood.emoji)
+                        .font(.system(size: 64))
+                    Text(mood.name)
+                        .font(.title2.bold())
                 }
-                .pickerStyle(SegmentedPickerStyle())
-            }
-            .padding()
+                .padding(.top)
 
-            Spacer()
+                VStack(spacing: 16) {
+                    Text("명상 시간")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity, alignment: .leading)
 
-            Button(action: {
-                isNavigatingToMeditation = true
-                AudioPlayerService.shared.stop()
-                navigate(.meditation(duration: duration, mood: mood, music: selectedMusic.id))
-            }) {
-                Text("명상 시작하기")
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(Color(mood.colorName))
-                    .foregroundColor(.white)
-                    .cornerRadius(16)
+                    Picker("시간 선택", selection: $duration) {
+                        ForEach(1...60, id: \.self) { minute in
+                            Text("\(minute)분").tag(minute)
+                        }
+                    }
+                    .pickerStyle(.wheel)
+                    .labelsHidden()
+                }
+                .padding()
+                .background(Color(.systemGray6))
+                .cornerRadius(20)
+                .padding(.horizontal)
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("배경 음악")
+                        .font(.headline)
+                    Picker("음악", selection: $selectedMusic) {
+                        ForEach(musicOptions) { option in
+                            Text(option.displayName)
+                                .tag(option)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+                .padding()
+                .background(Color(.systemGray6))
+                .cornerRadius(20)
+                .padding(.horizontal)
+
+                RoundedButton(title: "명상 시작하기", backgroundColor: Color(mood.colorName)) {
+                    isNavigatingToMeditation = true
+                    AudioPlayerService.shared.stop()
+                    navigate(.meditation(duration: duration, mood: mood, music: selectedMusic.id))
+                }
+                .padding(.horizontal)
             }
-            .padding(.horizontal)
+            .padding(.vertical)
         }
-        .padding()
+        .background(Color(mood.colorName).opacity(0.1))
         .navigationTitle("명상 설정")
         .onAppear {
             AudioPlayerService.shared.play(name: selectedMusic.id, loop: true)


### PR DESCRIPTION
## Summary
- modernize `MeditationSetupView` with emoji header and card‑style pickers
- use `RoundedButton` for start action
- apply mood‑tinted background for a fresh look

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6856c612ef048331adf76b5512377192