### PR TITLE
Add weekly completion grid

### DIFF
--- a/meditation/Views/Stats/StatsTabView.swift
+++ b/meditation/Views/Stats/StatsTabView.swift
@@ -128,24 +128,24 @@ struct StatsTabView: View {
                     ProgressView(value: viewModel.weeklyProgress)
                         .padding(.horizontal)
 
-                    let progressData = Calendar.current.weekdaySymbols.map { day in
-                        (day: day, value: viewModel.weeklyStats[day] == true ? 1 : 0)
-                    }
-
-                    Chart {
-                        ForEach(progressData, id: \.day) { item in
-                            LineMark(
-                                x: .value("Day", item.day),
-                                y: .value("완료", item.value)
-                            )
-                            PointMark(
-                                x: .value("Day", item.day),
-                                y: .value("완료", item.value)
-                            )
+                    HStack(spacing: 12) {
+                        ForEach(Calendar.current.weekdaySymbols, id: \.self) { day in
+                            VStack(spacing: 4) {
+                                Text(String(day.prefix(1)))
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                Image(systemName: viewModel.weeklyStats[day] == true ? "checkmark.circle.fill" : "circle")
+                                    .foregroundColor(viewModel.weeklyStats[day] == true ? .green : .gray)
+                            }
                         }
                     }
-                    .frame(height: 160)
+                    .frame(maxWidth: .infinity)
                     .padding(.horizontal)
+
+                    Text("초록 체크가 있는 요일은 명상 세션을 완료한 날을 의미합니다.")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal)
                 }
                 .padding()
                 .background(.thinMaterial)


### PR DESCRIPTION
## Summary
- replace weekly progress line chart with a simple checkmark grid
- caption explains what the checkmarks mean

## Testing
- `swift --version`
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f6ddcc94833182737a8a967ad4a4